### PR TITLE
fix: not showing icon for built-in toast types

### DIFF
--- a/src/components/toast-icon.tsx
+++ b/src/components/toast-icon.tsx
@@ -52,6 +52,10 @@ const ToastIcon: React.FC<ToastIconProps> = (props) => {
     return null;
   };
 
+  const hasIcon = renderIcon() !== null;
+
+  if (!hasIcon) return null;
+
   return <AnimatedIconWrapper>{renderIcon()}</AnimatedIconWrapper>;
 };
 

--- a/src/components/toaster.tsx
+++ b/src/components/toaster.tsx
@@ -60,7 +60,7 @@ export const Toaster: React.FC<ToasterProps> = (props) => {
                 alignItems: 'center',
               }}
             >
-              {icon && <ToastIcon type={type} icon={icon} />}
+              <ToastIcon type={type} icon={icon} />
               <div>
                 {title && <ToastTitle>{title}</ToastTitle>}
                 {description && (


### PR DESCRIPTION
## What

- Fix error not showing icon for some built-in types (success, error, waiting, ...)