### PR TITLE
[codex] Fix toast timer lifecycle and cumulative pause behavior

### DIFF
--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -51,7 +51,6 @@ type Action =
 export interface State {
   toasts: Toast[];
   pausedAt: number | undefined;
-  pauseDuration: number | undefined;
   toastLimit?: number;
 }
 
@@ -78,6 +77,14 @@ const clearFromRemoveQueue = (toastId: string) => {
   if (timeout) {
     clearTimeout(timeout);
   }
+  toastTimeouts.delete(toastId);
+};
+
+const clearRemoveQueue = () => {
+  toastTimeouts.forEach((timeout) => {
+    clearTimeout(timeout);
+  });
+  toastTimeouts.clear();
 };
 
 export const reducer = (state: State, action: Action): State => {
@@ -117,11 +124,14 @@ export const reducer = (state: State, action: Action): State => {
       const { toastId } = action;
 
       if (toastId === undefined) {
+        clearRemoveQueue();
         return {
           ...state,
           toasts: [],
         };
       }
+
+      clearFromRemoveQueue(toastId);
       return {
         ...state,
         toasts: state.toasts.filter((t) => t.id !== toastId),
@@ -148,6 +158,10 @@ export const reducer = (state: State, action: Action): State => {
     }
 
     case 'PAUSE': {
+      if (state.pausedAt !== undefined) {
+        return state;
+      }
+
       return {
         ...state,
         pausedAt: action.time,
@@ -155,11 +169,18 @@ export const reducer = (state: State, action: Action): State => {
     }
 
     case 'RESUME': {
-      const pauseDuration = action.time - (state.pausedAt || 0);
+      if (state.pausedAt === undefined) {
+        return state;
+      }
+
+      const pauseDuration = action.time - state.pausedAt;
       return {
         ...state,
         pausedAt: undefined,
-        pauseDuration,
+        toasts: state.toasts.map((toast) => ({
+          ...toast,
+          createdAt: toast.createdAt + pauseDuration,
+        })),
       };
     }
 
@@ -180,7 +201,6 @@ const listeners: Array<(state: State) => void> = [];
 let memoryState: State = {
   toasts: [],
   pausedAt: undefined,
-  pauseDuration: undefined,
   toastLimit: 3,
 };
 

--- a/src/core/use-toast.ts
+++ b/src/core/use-toast.ts
@@ -141,7 +141,7 @@ function useToast(toastOptions: ToastsOptions = {}): {
   toast: ToastHandler;
   dismiss: (toastId?: string) => void;
 } {
-  const { toasts, pausedAt, pauseDuration } = useStore(toastOptions);
+  const { toasts, pausedAt } = useStore(toastOptions);
 
   React.useEffect(() => {
     const timeouts = toasts.map((t) => {
@@ -154,9 +154,7 @@ function useToast(toastOptions: ToastsOptions = {}): {
       }
 
       const durationLeft =
-        (t.duration ?? DEFAULT_DURATION) +
-        (pauseDuration ?? 0) -
-        (Date.now() - t.createdAt);
+        (t.duration ?? DEFAULT_DURATION) - (Date.now() - t.createdAt);
 
       if (durationLeft <= 0) {
         if (t.visible) {
@@ -173,7 +171,7 @@ function useToast(toastOptions: ToastsOptions = {}): {
     return () => {
       timeouts.forEach((timeout) => timeout && clearTimeout(timeout));
     };
-  }, [toasts, pausedAt, pauseDuration]);
+  }, [toasts, pausedAt]);
 
   return {
     toasts,

--- a/tests/Toast.test.tsx
+++ b/tests/Toast.test.tsx
@@ -133,3 +133,86 @@ it('pause toasts correctly', () => {
   });
   expect(toastElement).not.toBeInTheDocument();
 });
+
+it('removes a toast after dismissing an updated toast with the same id', () => {
+  render(<Toaster />);
+
+  act(() => {
+    toast.loading({
+      id: 'same-toast',
+      title: 'Working',
+      duration: Infinity,
+    });
+  });
+
+  expect(screen.getByText(/working/i)).toBeInTheDocument();
+
+  act(() => {
+    toast.dismiss('same-toast');
+    vi.advanceTimersByTime(500);
+    toast.success({
+      id: 'same-toast',
+      title: 'Done',
+      duration: Infinity,
+    });
+    vi.advanceTimersByTime(1000);
+  });
+
+  expect(screen.getByText(/done/i)).toBeInTheDocument();
+
+  act(() => {
+    toast.dismiss('same-toast');
+    vi.advanceTimersByTime(1000);
+  });
+
+  expect(screen.queryByText(/done/i)).not.toBeInTheDocument();
+});
+
+it('preserves duration across multiple pauses', () => {
+  render(<Toaster />);
+
+  act(() => {
+    toast({
+      title: 'Multiple pauses',
+      duration: 3000,
+    });
+  });
+
+  const toastElement = screen.getByText(/multiple pauses/i);
+
+  act(() => {
+    vi.advanceTimersByTime(1000);
+  });
+  act(() => {
+    fireEvent.mouseEnter(toastElement);
+  });
+  act(() => {
+    vi.advanceTimersByTime(1000);
+  });
+  act(() => {
+    fireEvent.mouseLeave(toastElement);
+  });
+  act(() => {
+    vi.advanceTimersByTime(1000);
+  });
+  act(() => {
+    fireEvent.mouseEnter(toastElement);
+  });
+  act(() => {
+    vi.advanceTimersByTime(1000);
+  });
+  act(() => {
+    fireEvent.mouseLeave(toastElement);
+  });
+  act(() => {
+    vi.advanceTimersByTime(999);
+  });
+
+  expect(toastElement).toBeInTheDocument();
+
+  act(() => {
+    vi.advanceTimersByTime(1001);
+  });
+
+  expect(toastElement).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary

Fixes two toast timer lifecycle issues and adds regression coverage for both.

Before this change:

- If a toast was dismissed, then updated or reused with the same `id` before the dismiss removal timer finished, the old timer was cleared but kept in the internal map. A later dismiss for that same toast could be ignored, leaving it stuck.
- Hover pause only remembered the most recent pause duration. With multiple pauses, earlier pause time could be lost, so a toast could expire too early.
- The last pause duration lived in global state, so timer calculations could be affected more broadly than the active toast lifecycle needed.

After this change:

- Clearing a dismiss timer also removes it from the internal timer map, so reused toast IDs can be dismissed normally again.
- Removing all toasts clears all pending removal timers.
- Each pause/resume cycle adds paused time back to every active toast by shifting its `createdAt` forward, so multiple pauses accumulate correctly.
- New toasts are not affected by previous pause durations.

## Validation

- `yarn test:ci`
- `yarn type-check`
- `yarn lint`