### PR TITLE
Improve package size and refresh docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ https://github.com/nhanluongoe/react-stacked-toast/assets/42910096/ad5cf539-0c47
 
 - 🎨 **Customizable**: You can customize the toast notification by passing a React component
 
+- 🪶 **Small**: Published package is about 9.9 kB packed with optional subpath exports for focused imports
+
 ## 🏃 Getting started
 
 Using npm:

--- a/package.json
+++ b/package.json
@@ -34,8 +34,19 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
+    },
+    "./toast": {
+      "types": "./dist/toast.d.ts",
+      "require": "./dist/toast.js",
+      "import": "./dist/toast.mjs"
+    },
+    "./toaster": {
+      "types": "./dist/toaster.d.ts",
+      "require": "./dist/toaster.js",
+      "import": "./dist/toaster.mjs"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "yaml": ">=2.8.3"
   },
   "dependencies": {
-    "@emotion/react": "^11.11.3",
-    "@emotion/styled": "^11.11.0"
+    "csstype": "^3.0.10",
+    "goober": "^2.1.19"
   }
 }

--- a/site/pages/docs/index.mdx
+++ b/site/pages/docs/index.mdx
@@ -1,5 +1,4 @@
 import Layout from '../../components/docs-layout';
-import toast from 'react-stacked-toast';
 
 export const meta = {
   title: 'Documentation',
@@ -8,6 +7,8 @@ export const meta = {
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>;
 
 # Getting Started
+
+React Stacked Toast gives you a small toast store and a single `<Toaster />` component for rendering stacked notifications.
 
 ### Install with Yarn
 
@@ -30,37 +31,41 @@ import { Toaster } from 'react-stacked-toast';
 
 const App = () => {
   return (
-    <Toaster />
-    // Other components
+    <>
+      <Toaster />
+      {/* Other components */}
+    </>
   );
 };
 ```
 
-### 2. Use the `toast` api to create a toast anywhere in your application
+### 2. Use the `toast` API anywhere in your application
 
 ```jsx
 import { toast } from 'react-stacked-toast';
 
 const Component = () => {
   const handleClick = () => {
-    // Quickly make a toast
-    toast("Here is your toast");
+    toast('Here is your toast!');
 
-    // Or need more customization
     toast({
       title: 'React Stacked Toast',
       description: 'Here is your toast!',
-      icon: '🍞'
-      ...
+      icon: '🍞',
     });
-  }
+  };
 
-  return (
-    <button
-      onClick={handleClick}
-    >
-      Show toast
-    </button>
-  );
+  return <button onClick={handleClick}>Show toast</button>;
 };
+```
+
+## Package size
+
+The current build is about **9.9 kB packed** and **43.3 kB unpacked** based on `npm pack --dry-run`.
+
+The root import remains supported. If you prefer more focused entry points, you can import the toast API and toaster component separately:
+
+```jsx
+import toast from 'react-stacked-toast/toast';
+import { Toaster } from 'react-stacked-toast/toaster';
 ```

--- a/site/pages/docs/styling.mdx
+++ b/site/pages/docs/styling.mdx
@@ -1,5 +1,4 @@
 import Layout from '../../components/docs-layout';
-import toast from 'react-stacked-toast';
 
 export const meta = {
   title: 'Styling',
@@ -9,23 +8,27 @@ export default ({ children }) => <Layout meta={meta}>{children}</Layout>;
 
 # Styling
 
-You can style your toast globally with `toastOptions` in `<Toaster/>` component or individually with `toast()` api.
+You can style toasts globally with `toastOptions` on `<Toaster />`, or individually with the `toast()` API.
 
 ## Global styling
 
-You either can pass `style` or `className` to `toastOptions` to style your toast globally.
+Pass `style` or `className` to `toastOptions` to style every toast rendered by that toaster.
 
 ```jsx
-<Toaster toastOptions={{
-  style: {
-    background: '#333',
-    color: '#fff',
-  },
-  className="border border-red"
-}} />
+import { Toaster } from 'react-stacked-toast/toaster';
+
+<Toaster
+  toastOptions={{
+    style: {
+      background: '#333',
+      color: '#fff',
+    },
+    className: 'border border-red',
+  }}
+/>;
 ```
 
-You also can style the viewport. Viewport is the container of all toasts.
+You can also style the viewport. The viewport is the fixed container that holds the toast stack.
 
 ```jsx
 <Toaster
@@ -40,9 +43,11 @@ You also can style the viewport. Viewport is the container of all toasts.
 
 ## Individual styling
 
-You can pass `style` or `className` to `toast()` api to style your toast individually. This will override `toastOptions` styling in `<Toaster/>` component.
+Pass `style` or `className` to `toast()` to style one toast. Individual toast styles override matching `toastOptions` styles.
 
-```js
+```jsx
+import toast from 'react-stacked-toast/toast';
+
 toast({
   title: 'Hello',
   description: 'This is a toast',
@@ -50,6 +55,6 @@ toast({
     background: '#333',
     color: '#fff',
   },
-  className="border border-red"
-})
+  className: 'border border-red',
+});
 ```

--- a/site/pages/docs/toast.mdx
+++ b/site/pages/docs/toast.mdx
@@ -1,5 +1,4 @@
 import Layout from '../../components/docs-layout';
-import toast from 'react-stacked-toast';
 
 export const meta = {
   title: 'toast() API',
@@ -7,11 +6,25 @@ export const meta = {
 
 # `toast()` API
 
-## Available toast options
+Use `toast()` to create, update, dismiss, and remove notifications.
 
-These options will overwrite all options received from [`<Toaster/>`](/docs/toaster).
+## Import
 
 ```js
+import toast from 'react-stacked-toast/toast';
+```
+
+You can also import `toast` from the root package:
+
+```js
+import { toast } from 'react-stacked-toast';
+```
+
+## Available toast options
+
+Per-toast options override matching options received from [`<Toaster />`](/docs/toaster).
+
+```jsx
 toast({
   title: 'Hello world!',
   description: 'This is a toast notification.',
@@ -21,24 +34,33 @@ toast({
     backgroundColor: '#333',
     color: '#fff',
   },
+  className: 'toast-dark',
 });
 ```
 
-| Options       | Type          | Description                                                             |
+| Option        | Type          | Description                                                             |
 | ------------- | ------------- | ----------------------------------------------------------------------- |
+| `id`          | string        | Reuse an existing id to update that toast.                              |
 | `title`       | ReactNode     | The title of the toast notification.                                    |
 | `description` | ReactNode     | The description of the toast notification.                              |
 | `duration`    | number        | The duration of the toast notification in milliseconds. Default is 3000 |
 | `icon`        | ReactNode     | The icon to be displayed in the toast notification.                     |
-| `style`       | CSSProperties | The custom styles for the toast notification.                           |
+| `style`       | CSSProperties | Inline styles for the toast notification.                               |
+| `className`   | string        | A class name for the toast notification.                                |
+
+Set `duration` to `Infinity` to keep a toast visible until it is dismissed.
 
 ## Usage
 
-```js
-// Make a tost
+### Basic toast
+
+```jsx
+toast('Hello world!');
+
 toast({
   title: 'Hello world!',
 });
+
 toast({
   title: (
     <span>
@@ -46,8 +68,11 @@ toast({
     </span>
   ),
 });
+```
 
-// Shortcut to built-in types
+### Built-in types
+
+```js
 toast.success({
   title: 'Successfully created!',
 });
@@ -62,11 +87,11 @@ toast.warning({
   title: 'Overcooked!',
   description: 'Your toast is overcooked!',
 });
-toast.custom({
-  title: <div>Hello World</div>,
-});
+```
 
-// Make a dark toast
+### Custom styling
+
+```js
 toast({
   title: 'Why not a dark toast?',
   icon: '👏',
@@ -75,21 +100,35 @@ toast({
     background: '#333',
     color: '#fff',
   },
+  className: 'toast-dark',
 });
+```
 
-// Promise
+### Promise states
+
+```js
 const resolveAfter3Sec = new Promise((resolve) => setTimeout(resolve, 3000));
 toast.promise(resolveAfter3Sec, {
   loading: { title: 'Loading...', description: 'Waiting for 3 seconds.' },
   success: { title: 'Success!', description: 'Your toast is ready.' },
   error: { title: 'Error!', description: 'Your toast is burnt.' },
 });
+```
 
-// Dismiss a single toast
+### Dismiss toasts
+
+```js
 const toastId = toast({ title: 'Hello world!' });
 toast.dismiss(toastId);
 
-//or
+toast.dismiss();
+```
+
+### Render from the current toast
+
+Pass a function when the content needs access to the generated toast id.
+
+```jsx
 toast((t) => ({
   title: (
     <span>
@@ -98,9 +137,12 @@ toast((t) => ({
     </span>
   ),
 }));
+```
 
-// Dismiss all toasts
-toast.dismiss();
+### Remove all toasts immediately
+
+```js
+toast.remove();
 ```
 
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/site/pages/docs/toaster.mdx
+++ b/site/pages/docs/toaster.mdx
@@ -1,46 +1,75 @@
 import Layout from '../../components/docs-layout';
-import toast from 'react-stacked-toast';
 
 export const meta = {
-  title: '<Toaster/> API',
+  title: '<Toaster /> API',
 };
 
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>;
 
 # `<Toaster />` API
 
+Render one `<Toaster />` near the root of your application. It subscribes to toast state and displays the active stack.
+
+## Import
+
+```jsx
+import { Toaster } from 'react-stacked-toast/toaster';
+```
+
+You can also import `Toaster` from the root package:
+
+```jsx
+import { Toaster } from 'react-stacked-toast';
+```
+
 ## Available options
 
 ```jsx
+import { Toaster } from 'react-stacked-toast/toaster';
+
 <Toaster
   position="right"
   toastOptions={{
     duration: 3 * 1000,
     icon: '👋',
+    toastLimit: 3,
     style: {
       backgroundColor: '#333',
       color: '#fff',
     },
+    className: 'toast',
+    viewportStyle: {
+      top: 24,
+    },
+    viewportClassName: 'toast-viewport',
   }}
-/>
+/>;
 ```
 
-| Props        | Type                          | Default | Description                                      |
-| ------------ | ----------------------------- | ------- | ------------------------------------------------ |
-| position     | 'right' \| 'center' \| 'left' | 'right' | The position of the toaster on the screen        |
-| toastOptions | object                        | \{\}    | Options for customizing the appearance of toasts |
+| Prop           | Type                            | Default   | Description                                      |
+| -------------- | ------------------------------- | --------- | ------------------------------------------------ |
+| `position`     | `'right' \| 'center' \| 'left'` | `'right'` | The position of the toaster on the screen.       |
+| `toastOptions` | object                          | `{}`      | Options for customizing the appearance of toasts |
 
-| Options      | Type          | Description                                                             |
-| ------------ | ------------- | ----------------------------------------------------------------------- |
-| `duration`   | number        | The duration of the toast notification in milliseconds. Default is 3000 |
-| `icon`       | ReactNode     | The icon to be displayed in the toast notification.                     |
-| `style`      | CSSProperties | The custom styles for the toast notification.                           |
-| `toastLimit` | number        | The maximum number of visible toasts. Default is 3.                     |
+| `toastOptions` option | Type          | Description                                                 |
+| --------------------- | ------------- | ----------------------------------------------------------- |
+| `duration`            | number        | The duration of each toast in milliseconds. Default is 3000 |
+| `icon`                | ReactNode     | The default icon for toast notifications.                   |
+| `style`               | CSSProperties | Inline styles applied to each toast.                        |
+| `className`           | string        | A class name applied to each toast.                         |
+| `toastLimit`          | number        | The maximum number of visible toasts. Default is 3.         |
+| `viewportStyle`       | CSSProperties | Inline styles applied to the toast viewport.                |
+| `viewportClassName`   | string        | A class name applied to the toast viewport.                 |
 
 ## Usage
 
 ```jsx
-import { Toaster } from 'react-stacked-toast';
+import { Toaster } from 'react-stacked-toast/toaster';
 
-<Toaster />;
+export const App = () => (
+  <>
+    <Toaster position="right" />
+    {/* Other components */}
+  </>
+);
 ```

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,6 +1,5 @@
-import styled from '@emotion/styled';
-import { keyframes } from '@emotion/react';
 import React from 'react';
+import { keyframes, styled } from '../core/goober';
 
 const StyledCheck = styled('i')`
   & {

--- a/src/components/toast-icon.tsx
+++ b/src/components/toast-icon.tsx
@@ -1,6 +1,5 @@
-import styled from '@emotion/styled';
-import { keyframes } from '@emotion/react';
 import React from 'react';
+import { keyframes, styled } from '../core/goober';
 import { Toast } from '../core/types';
 import { Check, Close, Spinner, Warning } from './icons';
 

--- a/src/components/toast.tsx
+++ b/src/components/toast.tsx
@@ -1,7 +1,6 @@
-import styled from '@emotion/styled';
 import React, { CSSProperties, HTMLAttributes } from 'react';
+import { keyframes, styled } from '../core/goober';
 import { ReactChildren } from '../core/types';
-import { keyframes } from '@emotion/react';
 
 interface ToastViewportProps {
   position: 'left' | 'center' | 'right';
@@ -81,8 +80,6 @@ const StyledToast = styled('li')`
   line-height: 1.3;
   padding: 16px;
   margin-bottom: 8px;
-  animation: ${(props: ToastProps) => (props.visible ? fadeIn : fadeOut)} 0.5s
-    forwards cubic-bezier(0.06, 0.71, 0.55, 1);
 `;
 
 const Toast: React.FC<ToastProps> = (props) => {
@@ -100,10 +97,12 @@ const Toast: React.FC<ToastProps> = (props) => {
     <StyledToast
       style={{
         ...animationStyle,
+        animation: `${
+          visible ? fadeIn : fadeOut
+        } 0.5s forwards cubic-bezier(0.06, 0.71, 0.55, 1)`,
         ...style,
       }}
       className={className}
-      visible={visible}
     >
       {children}
     </StyledToast>

--- a/src/core/goober.ts
+++ b/src/core/goober.ts
@@ -1,0 +1,6 @@
+import React from 'react';
+import { keyframes, setup, styled } from 'goober';
+
+setup(React.createElement);
+
+export { keyframes, styled };

--- a/src/toast.ts
+++ b/src/toast.ts
@@ -1,0 +1,4 @@
+import { toast } from './core/use-toast';
+
+export { toast };
+export default toast;

--- a/src/toaster.ts
+++ b/src/toaster.ts
@@ -1,0 +1,2 @@
+export { Toaster } from './components/toaster';
+export type { ToasterProps } from './components/toaster';

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -17,7 +17,7 @@ export default defineConfig([
         js: '"use client";',
       };
     },
-    entry: ['src/index.ts'],
+    entry: ['src/index.ts', 'src/toast.ts', 'src/toaster.ts'],
     outDir: 'dist',
   },
 ]);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,7 +5,7 @@ const commonConfig: Options = {
   minify: true,
   dts: true,
   format: ['esm', 'cjs'],
-  sourcemap: true,
+  sourcemap: false,
   clean: true,
 };
 export default defineConfig([

--- a/yarn.lock
+++ b/yarn.lock
@@ -233,7 +233,7 @@
     "@babel/traverse" "^7.29.7"
     "@babel/types" "^7.29.7"
 
-"@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.22.15":
+"@babel/helper-module-imports@^7.22.15":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz#16146307acdc40cc00c3b2c647713076464bdbf0"
   integrity sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==
@@ -1060,7 +1060,7 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@7.29.7", "@babel/runtime@^7.12.5", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.21.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.9.2":
+"@babel/runtime@7.29.7", "@babel/runtime@^7.12.5", "@babel/runtime@^7.17.8", "@babel/runtime@^7.21.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.9.2":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
   integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
@@ -1369,113 +1369,6 @@
   integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
-
-"@emotion/babel-plugin@^11.11.0":
-  version "11.11.0"
-  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz#c2d872b6a7767a9d176d007f5b31f7d504bb5d6c"
-  integrity sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==
-  dependencies:
-    "@babel/helper-module-imports" "^7.16.7"
-    "@babel/runtime" "^7.18.3"
-    "@emotion/hash" "^0.9.1"
-    "@emotion/memoize" "^0.8.1"
-    "@emotion/serialize" "^1.1.2"
-    babel-plugin-macros "^3.1.0"
-    convert-source-map "^1.5.0"
-    escape-string-regexp "^4.0.0"
-    find-root "^1.1.0"
-    source-map "^0.5.7"
-    stylis "4.2.0"
-
-"@emotion/cache@^11.11.0":
-  version "11.11.0"
-  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.11.0.tgz#809b33ee6b1cb1a625fef7a45bc568ccd9b8f3ff"
-  integrity sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==
-  dependencies:
-    "@emotion/memoize" "^0.8.1"
-    "@emotion/sheet" "^1.2.2"
-    "@emotion/utils" "^1.2.1"
-    "@emotion/weak-memoize" "^0.3.1"
-    stylis "4.2.0"
-
-"@emotion/hash@^0.9.1":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.1.tgz#4ffb0055f7ef676ebc3a5a91fb621393294e2f43"
-  integrity sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==
-
-"@emotion/is-prop-valid@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz#23116cf1ed18bfeac910ec6436561ecb1a3885cc"
-  integrity sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==
-  dependencies:
-    "@emotion/memoize" "^0.8.1"
-
-"@emotion/memoize@^0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.1.tgz#c1ddb040429c6d21d38cc945fe75c818cfb68e17"
-  integrity sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==
-
-"@emotion/react@^11.11.3":
-  version "11.11.3"
-  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.11.3.tgz#96b855dc40a2a55f52a72f518a41db4f69c31a25"
-  integrity sha512-Cnn0kuq4DoONOMcnoVsTOR8E+AdnKFf//6kUWc4LCdnxj31pZWn7rIULd6Y7/Js1PiPHzn7SKCM9vB/jBni8eA==
-  dependencies:
-    "@babel/runtime" "^7.18.3"
-    "@emotion/babel-plugin" "^11.11.0"
-    "@emotion/cache" "^11.11.0"
-    "@emotion/serialize" "^1.1.3"
-    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.1"
-    "@emotion/utils" "^1.2.1"
-    "@emotion/weak-memoize" "^0.3.1"
-    hoist-non-react-statics "^3.3.1"
-
-"@emotion/serialize@^1.1.2", "@emotion/serialize@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.1.3.tgz#84b77bfcfe3b7bb47d326602f640ccfcacd5ffb0"
-  integrity sha512-iD4D6QVZFDhcbH0RAG1uVu1CwVLMWUkCvAqqlewO/rxf8+87yIBAlt4+AxMiiKPLs5hFc0owNk/sLLAOROw3cA==
-  dependencies:
-    "@emotion/hash" "^0.9.1"
-    "@emotion/memoize" "^0.8.1"
-    "@emotion/unitless" "^0.8.1"
-    "@emotion/utils" "^1.2.1"
-    csstype "^3.0.2"
-
-"@emotion/sheet@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.2.tgz#d58e788ee27267a14342303e1abb3d508b6d0fec"
-  integrity sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==
-
-"@emotion/styled@^11.11.0":
-  version "11.11.0"
-  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.11.0.tgz#26b75e1b5a1b7a629d7c0a8b708fbf5a9cdce346"
-  integrity sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==
-  dependencies:
-    "@babel/runtime" "^7.18.3"
-    "@emotion/babel-plugin" "^11.11.0"
-    "@emotion/is-prop-valid" "^1.2.1"
-    "@emotion/serialize" "^1.1.2"
-    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.1"
-    "@emotion/utils" "^1.2.1"
-
-"@emotion/unitless@^0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.8.1.tgz#182b5a4704ef8ad91bde93f7a860a88fd92c79a3"
-  integrity sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==
-
-"@emotion/use-insertion-effect-with-fallbacks@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz#08de79f54eb3406f9daaf77c76e35313da963963"
-  integrity sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==
-
-"@emotion/utils@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.2.1.tgz#bbab58465738d31ae4cb3dbb6fc00a5991f755e4"
-  integrity sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==
-
-"@emotion/weak-memoize@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz#d0fce5d07b0620caa282b5131c297bb60f9d87e6"
-  integrity sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==
 
 "@esbuild/aix-ppc64@0.28.0":
   version "0.28.0"
@@ -3591,15 +3484,6 @@ babel-loader@9.1.3:
     find-cache-dir "^4.0.0"
     schema-utils "^4.0.0"
 
-babel-plugin-macros@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1"
-  integrity sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    cosmiconfig "^7.0.0"
-    resolve "^1.19.0"
-
 babel-plugin-polyfill-corejs2@^0.4.15:
   version "0.4.17"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz#198f970f1c99a856b466d1187e88ce30bd199d91"
@@ -4185,11 +4069,6 @@ conventional-commits-parser@^5.0.0:
     meow "^12.0.1"
     split2 "^4.0.0"
 
-convert-source-map@^1.5.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
-  integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
-
 convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
@@ -4296,15 +4175,15 @@ cssstyle@^3.0.0:
   dependencies:
     rrweb-cssom "^0.6.0"
 
+csstype@^3.0.10, csstype@^3.2.2:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
+  integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
+
 csstype@^3.0.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
-
-csstype@^3.2.2:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
-  integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
 damerau-levenshtein@^1.0.8:
   version "1.0.8"
@@ -5807,6 +5686,11 @@ globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+goober@^2.1.19:
+  version "2.1.19"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.19.tgz#a4b4dcdbba9325b8c4d7380099f9f281f27c6a6f"
+  integrity sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -5920,13 +5804,6 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
-
-hoist-non-react-statics@^3.3.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
-  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
-  dependencies:
-    react-is "^16.7.0"
 
 homedir-polyfill@^1.0.1:
   version "1.0.3"
@@ -8124,7 +8001,7 @@ react-dom@^19.2.1:
   dependencies:
     scheduler "^0.27.0"
 
-react-is@^16.13.1, react-is@^16.7.0:
+react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -8430,7 +8307,7 @@ resolve@^1.10.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-resolve@^1.19.0, resolve@^1.22.1, resolve@^1.22.4:
+resolve@^1.22.1, resolve@^1.22.4:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
@@ -8839,11 +8716,6 @@ source-map-support@~0.5.20:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map@^0.5.7:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-  integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
-
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
@@ -9095,11 +8967,6 @@ style-loader@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.2.tgz#eaebca714d9e462c19aa1e3599057bc363924899"
   integrity sha512-RHs/vcrKdQK8wZliteNK4NKzxvLBzpuHMqYmUVWeKa6MkaIQ97ZTOS0b+zapZhy6GcrgWnvWYCMHRirC3FsUmw==
-
-stylis@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.2.0.tgz#79daee0208964c8fe695a42fcffcac633a211a51"
-  integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
 
 sucrase@^3.35.0:
   version "3.35.1"


### PR DESCRIPTION
## Summary
- Replace Emotion with Goober and add focused `toast` and `toaster` subpath exports
- Disable source maps to reduce published package size
- Refresh README and site docs with current size, import paths, and corrected API examples

## Testing
- `yarn type-check`
- `yarn lint`
- `yarn test --run`
- `./node_modules/.bin/tsup`
- `yarn --cwd site build`